### PR TITLE
Fix deserialization bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'ml.echelon133'
-version '1.1.1-SNAPSHOT'
+version '1.1.2-SNAPSHOT'
 
 sourceCompatibility = 11.0
 

--- a/src/main/java/ml/echelon133/graph/json/GraphDeserializer.java
+++ b/src/main/java/ml/echelon133/graph/json/GraphDeserializer.java
@@ -91,7 +91,13 @@ public class GraphDeserializer extends StdDeserializer<Graph<BigDecimal>> {
 
             Vertex<BigDecimal> v = new Vertex<>(vertexElem.textValue());
 
-            outputGraph.addVertex(v);
+            try {
+                outputGraph.addVertex(v);
+            } catch (IllegalArgumentException ex) {
+                String msg = String.format("Vertex with name %s already belongs to the graph", v.getName());
+                throw new VertexAlreadyInGraphException(msg);
+            }
+
             // add every vertex to the map, this map will make reconstructing edges faster
             vertexHelperMap.put(vertexElem.textValue(), v);
         }

--- a/src/main/java/ml/echelon133/graph/json/exception/VertexAlreadyInGraphException.java
+++ b/src/main/java/ml/echelon133/graph/json/exception/VertexAlreadyInGraphException.java
@@ -1,0 +1,10 @@
+package ml.echelon133.graph.json.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class VertexAlreadyInGraphException extends JsonProcessingException {
+
+    public VertexAlreadyInGraphException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/ml/echelon133/graph/GraphDeserializerTest.java
+++ b/src/test/java/ml/echelon133/graph/GraphDeserializerTest.java
@@ -320,4 +320,21 @@ public class GraphDeserializerTest {
 
         assertEquals(expectedMessage, receivedMessage);
     }
+
+    @Test
+    public void graphContainingDuplicateVertexesCausesVertexAlreadyInGraphException() {
+        String receivedMessage = "";
+
+        String json = "{\"vertexes\": [\"v1\", \"v1\"], \"edges\": [{\"source\" : \"v1\", \"destination\" : \"v1\", \"weight\" : \"10\"}]}";
+
+        String expectedMessage = "Vertex with name v1 already belongs to the graph";
+
+        try {
+            Graph<BigDecimal> graph = mapper.readValue(json, graphBigDecimalType);
+        } catch (IOException ex) {
+            receivedMessage = ex.getMessage();
+        }
+
+        assertEquals(expectedMessage, receivedMessage);
+    }
 }


### PR DESCRIPTION
Now when graph deserializer encounters a duplicate vertex name during the deserialization process, it throws JsonProcessingException instead of a regular Exception. 